### PR TITLE
fix: add flag to prevent trying to change status code after response is already formed

### DIFF
--- a/app.js
+++ b/app.js
@@ -2415,14 +2415,17 @@ app.get("/filter", (req, res) => {
 // Route to retrieve a specific secret by key
 app.get("/activity/:key", (req, res) => {
   const key = req.params.key;
+  let activityFound = false;
   data.activities.forEach((activity) => {
     if (activity.key == key) {
       console.log(true);
       res.json(activity);
+      activityFound = true;
     }
   });
-
-  res.status(404).json({ error: "Activity not found" });
+  if (!activityFound) {
+    res.status(404).json({ error: "Activity not found" });
+  }
 });
 
 const port = 4000;


### PR DESCRIPTION
Hello, while using this app during [The Complete Full-Stack Web Development Bootcamp](https://www.udemy.com/course/the-complete-web-development-bootcamp/) (which I absolutely love by the way!), I've found a small bug in the **/activity/:key** route handler, which produces an error on the server side (ERR_HTTP_HEADERS_SENT), when a correct activity key is provided.

I would like to submit a fix for that problem. Here's what I've changed:
Added an `activityFound` flag in "/activity/:key" route handler, to prevent modifying the status code to 404 in case a matching activity has been found. This prevents the following error from happening: "Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client"

Best regards,
Artur